### PR TITLE
License file on -minimal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "upstream"]
 	path = upstream
-	url = git://github.com/vim/vim.git
+	url = https://github.com/vim/vim.git

--- a/rpm/vim.spec
+++ b/rpm/vim.spec
@@ -313,6 +313,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files minimal
 %defattr(-,root,root)
+%license runtime/doc/uganda.txt
 %config(noreplace) %{_sysconfdir}/virc
 /bin/ex
 /bin/vi


### PR DESCRIPTION
The -minimal being smaller replacement it doesn't pull in the common files. Let's include the license file separately here.

@Tomin1 @mlehtima 